### PR TITLE
Fixed transport_interface_test.cmake naming

### DIFF
--- a/src/transport_interface_test.cmake
+++ b/src/transport_interface_test.cmake
@@ -1,4 +1,4 @@
-set( TRANSPORT_TEST_SOURCES "${CMAKE_CURRENT_LIST_DIR}/transport_interface/transport_interface_tests.c" )
+set( TRANSPORT_TEST_SOURCES "${CMAKE_CURRENT_LIST_DIR}/transport_interface/transport_interface_test.c" )
 set( TRANSPORT_TEST_INCLUDE_DIRS
     "${CMAKE_CURRENT_LIST_DIR}/transport_interface"
     "${CMAKE_CURRENT_LIST_DIR}/common" )


### PR DESCRIPTION
Renamed transport_interface_tests.cmake to transport_interface_test.cmake to be consistent with the rest of the repo. Also fixed naming in the cmake file.