### PR TITLE
Removed deprecated links in doc and fixed typo

### DIFF
--- a/src/transport_interface/README.md
+++ b/src/transport_interface/README.md
@@ -244,7 +244,7 @@ go run echo_server.go -config=example_config.json
 ### 6.2. Start the echo server with TLS
 Developer’s can also setup the transport interface test over mutual authenticated TLS with this echo server tool. Echo server must setup with the **secure-connection** configuration and provide server certificate and key in the configuration file. TLS connection capability and client certificate will be verified by the echo server.
 
-This [document](https://github.com/FreeRTOS/freertos-integration-toolkit/blob/main/transport_interface_test/tools/echo_server/readme.md) describes how to create self-signed credentials for the echo server. The self-signed credentials is only for test transport interface test.
+This document describes how to create self-signed credentials for the echo server. The self-signed credentials is only for test transport interface test.
 
 To run the echo serve with TLS, the following configuraition file, "example_tls_config.json", can be referenced as an example to run the echo server. 
 ```

--- a/tools/echo_server/README.md
+++ b/tools/echo_server/README.md
@@ -34,7 +34,7 @@ The JSON file contains the following options:
     "secure-connection": false,
     "server-port": "9000",
     "server-certificate-location": "./certs/server.pem",
-    "server-key-location": "./certs/server.pem"
+    "server-key-location": "./certs/server.key"
 }
 ```
 


### PR DESCRIPTION
This PR removes a link in transport interface test README that refers to a doc in Integrator's Toolkit. Since the link is supposed to point to the document itself, it is removed instead of updated.
This PR also fixed a typo in echo server README.