### PR TITLE
Update transport interface test

### DIFF
--- a/src/common/thread_function.h
+++ b/src/common/thread_function.h
@@ -1,0 +1,71 @@
+/*
+ * FreeRTOS FreeRTOS LTS Qualification Tests preview
+ * Copyright (C) 2022 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * @file thread_function.h
+ * @brief Thread create/wait/Delay function for test application.
+ */
+#ifndef THREAD_FUNCTION_H
+#define THREAD_FUNCTION_H
+
+/**
+ * @brief Thread handle data structure definition.
+ */
+typedef void * ThreadHandle_t;
+
+/**
+ * @brief Thread function to be executed in ThreadCreate_t function.
+ *
+ * @param[in] pParam The pParam parameter passed in ThreadCreate_t function.
+ */
+typedef void ( * ThreadFunction_t )( void * pParam );
+
+/**
+ * @brief Thread create function for test application.
+ *
+ * @param[in] threadFunc The thread function to be executed in the created thread.
+ * @param[in] pParam The pParam parameter passed to the thread function pParam parameter.
+ *
+ * @return NULL if create thread failed. Otherwise, return the handle of the created thread.
+ */
+typedef ThreadHandle_t ( * ThreadCreate_t )( ThreadFunction_t threadFunc,
+                                             void * pParam );
+
+/**
+ * @brief Timed waiting function to wait for the created thread exit.
+ *
+ * @param[in] threadHandle The handle of the created thread to be waited.
+ * @param[in] timeoutMs The timeout value of to wait for the created thread exit.
+ *
+ * @return 0 if the thread exits within timeoutMs. Other value will be regarded as error.
+ */
+typedef int ( * ThreadTimedWait_t )( ThreadHandle_t threadHandle,
+                                     uint32_t timeoutMs );
+
+/**
+ * @brief Delay function to wait for the key generation.
+ *
+ * @param[in] delayMs Delay in milliseconds.
+ */
+typedef void (* ThreadDelayFunc_t )( uint32_t delayMs );
+
+#endif /* THREAD_FUNCTION_H */

--- a/src/transport_interface/README.md
+++ b/src/transport_interface/README.md
@@ -30,16 +30,20 @@ The transport interface tests verify the implementation by running various test 
 
 |Test Case	|Test Case Detail	|Expected result	|
 |---	|---	|---	|
-|Transport_SendOneByteRecvCompare 	|Test send receive beharivor in the following order<br>Send : 1 byte<br>Send : ( TRANSPORT_TEST_BUFFER_WRITABLE_LENGTH - 1 ) bytes<br>Receive : TRANSPORT_TEST_BUFFER_WRITABLE_LENGTH bytes | Send/receive/compare should has no error |
-|Transport_SendRecvOneByteCompare 	|Test send receive beharivor in the following order<br>Send : TRANSPORT_TEST_BUFFER_WRITABLE_LENGTH bytes<br>Receive : 1 byte<br>Receive : ( TRANSPORT_TEST_BUFFER_WRITABLE_LENGTH - 1 ) bytes |Send/receive/compare should has no error|
+|Transport_SendOneByteRecvCompare 	|Test send receive behavior in the following order<br>Send : 1 byte<br>Send : ( TRANSPORT_TEST_BUFFER_WRITABLE_LENGTH - 1 ) bytes<br>Receive : TRANSPORT_TEST_BUFFER_WRITABLE_LENGTH bytes | Send/receive/compare should has no error |
+|Transport_SendRecvOneByteCompare 	|Test send receive behavior in the following order<br>Send : TRANSPORT_TEST_BUFFER_WRITABLE_LENGTH bytes<br>Receive : 1 byte<br>Receive : ( TRANSPORT_TEST_BUFFER_WRITABLE_LENGTH - 1 ) bytes |Send/receive/compare should has no error|
 |Transport_SendRecvCompare 	|Test transport interface with send, receive and compare on bulk of data.<br>The data size ranges from 1 byte to TRANSPORT_TEST_BUFFER_WRITABLE_LENGTH bytes |Send/receive/compare should has no error within timeout |
 |Transport_SendRecvCompareMultithreaded 	|Test transport interface with send, receive and compare on bulk of data in multiple threads.<br>Each thread will create a network connection.<br>The data size ranges from 1 byte to TRANSPORT_TEST_BUFFER_WRITABLE_LENGTH bytes |Send/receive/compare should has no error within timeout |
 |TransportSend_RemoteDisconnect	|Test transport interface send function return value when disconnected by remote server	|Negative value should be returned	|
 |TransportRecv_RemoteDisconnect	|Test transport interface receive function return value when disconnected by remote server	|Negative value should be returned	|
 |TransportRecv_NoDataToReceive	|Test transport interface receive function return value when no data to receive	|0 should be returned	|
-|TransportRecv_ReturnZeroRetry	|Test transport interface receive function return zero due to no data to receive.<br> Send some data to echo server then retry the receive function.	|Postive value should be returned after retry	|
+|TransportRecv_ReturnZeroRetry	|Test transport interface receive function return zero due to no data to receive. Send data to echo server then retry the receive function. Transport receive function should be able to receive data from echo server and return positive value.	|Postive value should be returned after retry transport receive	|
 
-The following test cases are optional. Assertion may be required to be disabled to pass the test cases.
+Invalid parameter tests are not suitable to verify transport interface implementation which make use
+of assert to check invalid parameter. Therefore, they are optional and are provided for developers who want to verify their invalid parameters handling.
+
+Define **TRANSPORT_TEST_INVALID_PARAMETERS** to 1 in **test_param_config.h** if you want to run the invalid parameter tests.
+
 |Test Case	|Test Case Detail	|Expected result	|
 |---	|---	|---	|
 |TransportSend_NetworkContextNullPtr	|Test transport interface send with NULL network context pointer handling	|Negative value should be returned	|
@@ -92,6 +96,7 @@ Developer implements the transport interface test application with the following
 3. Include relevant files into the build system. If using CMake, qualification_test.cmake and src/transport_interface_tests.cmake can be used to include relevant files.
 
 4. Implement the setup function, **SetupTransportTestParam**, for transport interface test to provide test parameters. The following are required test parameters:
+
 ```C
 /**
  * @brief A struct representing transport interface test parameters.
@@ -119,12 +124,13 @@ typedef struct TransportTestParam
 void SetupTransportTestParam( TransportTestParam_t * pTestParam );
 ```
 
-4. Enable the transport interface config, **TRANSPORT_INTERFACE_TEST_ENABLED**, in **test_execution_config.h**.
+5. Enable the transport interface config, **TRANSPORT_INTERFACE_TEST_ENABLED**, in **test_execution_config.h**.
+
 ```C
 #define TRANSPORT_INTERFACE_TEST_ENABLED  ( 1 )     /* Set 1 to enable the transport interface test. */
 ```
 
-5. Implement the main function and call the **RunQualificationTest**.
+6. Implement the main function and call the **RunQualificationTest**.
 
 The following is an example test application.
 

--- a/src/transport_interface/transport_interface_test.c
+++ b/src/transport_interface/transport_interface_test.c
@@ -692,7 +692,7 @@ TEST( Full_TransportInterfaceTest, Transport_SendRecvCompareMultithreaded )
     /* The primary thread parameter already setup in the test setup function. */
     for( threadIndex = 1; threadIndex < TRANSPORT_TEST_MULTI_THREAD_TASK_COUNT; threadIndex++ )
     {
-        memset( threadParameter[ 1 ].transportTestBuffer,
+        memset( threadParameter[ threadIndex ].transportTestBuffer,
                 TRANSPORT_TEST_BUFFER_GUARD_PATTERN, TRANSPORT_TEST_BUFFER_TOTAL_LENGTH );
     }
 

--- a/src/transport_interface/transport_interface_test.c
+++ b/src/transport_interface/transport_interface_test.c
@@ -367,7 +367,7 @@ static void prvSendRecvCompareFunc( void * pParam )
 
 /*-----------------------------------------------------------*/
 
-static void prvRetunZeroRetryFunc( void *pParam )
+static void prvRetunZeroRetryFunc( void * pParam )
 {
     threadParameter_t * pThreadParameter = pParam;
     int32_t transportResult = 0;
@@ -388,8 +388,8 @@ static void prvRetunZeroRetryFunc( void *pParam )
                                          TRANSPORT_TEST_BUFFER_WRITABLE_LENGTH,
                                          "transportTestBuffer should not be altered." );
 
-    /* Send some data to echo server then retry the receive operation.
-     * The receive operation should be able to receive all the data. */
+    /* Send some data to echo server then retry the receive operation. The receive
+     * operation should be able to receive all the data. */
     /* Initialize the test data. */
     prvInitializeTestData( pTrasnportTestBufferStart, TRANSPORT_TEST_BUFFER_WRITABLE_LENGTH );
 
@@ -405,7 +405,7 @@ static void prvRetunZeroRetryFunc( void *pParam )
 
 /*-----------------------------------------------------------*/
 
-static void prvNoDataToReceiveFunc( void *pParam )
+static void prvNoDataToReceiveFunc( void * pParam )
 {
     threadParameter_t * pThreadParameter = pParam;
     int32_t transportResult = 0;
@@ -827,10 +827,12 @@ TEST( Full_TransportInterfaceTest, TransportRecv_NoDataToReceive )
     /* Waiting for the test thread complete. */
     timedWaitResult = testParam.pTestThreadTimedWait( threadHandle,
                                                       TRANSPORT_TEST_WAIT_THREAD_RECEIVE_TIMEOUT_MS );
+
     if( timedWaitResult != 0 )
     {
         threadParameter[ TRANSPORT_TEST_INDEX ].stopFlag = true;
     }
+
     TEST_ASSERT_MESSAGE( timedWaitResult == 0, "Waiting for test thread receive data failed." );
 }
 
@@ -858,10 +860,12 @@ TEST( Full_TransportInterfaceTest, TransportRecv_ReturnZeroRetry )
     /* Waiting for the test thread complete. */
     timedWaitResult = testParam.pTestThreadTimedWait( threadHandle,
                                                       TRANSPORT_TEST_WAIT_THREAD_RECEIVE_TIMEOUT_MS );
+
     if( timedWaitResult != 0 )
     {
         threadParameter[ TRANSPORT_TEST_INDEX ].stopFlag = true;
     }
+
     TEST_ASSERT_MESSAGE( timedWaitResult == 0, "Waiting for test thread receive data failed." );
 }
 

--- a/src/transport_interface/transport_interface_test.c
+++ b/src/transport_interface/transport_interface_test.c
@@ -64,15 +64,6 @@
       TRANSPORT_TEST_BUFFER_SUFFIX_GUARD_LENGTH )
 
 /**
- * @brief Test invalid parameters with transport interface.
- *
- * These test cases are optional since they may required user to disable assertion.
- */
-#ifndef TRANSPORT_TEST_INVALID_PARAMETERS
-    #define TRANSPORT_TEST_INVALID_PARAMETERS    ( 0 )
-#endif
-
-/**
  * @brief Transport Interface test buffer guard pattern.
  */
 #define TRANSPORT_TEST_BUFFER_GUARD_PATTERN        ( 0xA5 )
@@ -876,15 +867,13 @@ TEST( Full_TransportInterfaceTest, TransportRecv_ReturnZeroRetry )
  */
 TEST_GROUP_RUNNER( Full_TransportInterfaceTest )
 {
-    /* Optional invalid parameter tests. Disable assertion may be required to run these tests. */
-    #if ( TRANSPORT_TEST_INVALID_PARAMETERS == 1 )
-        RUN_TEST_CASE( Full_TransportInterfaceTest, TransportSend_NetworkContextNullPtr );
-        RUN_TEST_CASE( Full_TransportInterfaceTest, TransportSend_BufferNullPtr );
-        RUN_TEST_CASE( Full_TransportInterfaceTest, TransportSend_ZeroByteToSend );
-        RUN_TEST_CASE( Full_TransportInterfaceTest, TransportRecv_NetworkContextNullPtr );
-        RUN_TEST_CASE( Full_TransportInterfaceTest, TransportRecv_BufferNullPtr );
-        RUN_TEST_CASE( Full_TransportInterfaceTest, TransportRecv_ZeroByteToRecv );
-    #endif
+    /* Invalid parameter test. Disable or replace assert may be required to run these tests. */
+    RUN_TEST_CASE( Full_TransportInterfaceTest, TransportSend_NetworkContextNullPtr );
+    RUN_TEST_CASE( Full_TransportInterfaceTest, TransportSend_BufferNullPtr );
+    RUN_TEST_CASE( Full_TransportInterfaceTest, TransportSend_ZeroByteToSend );
+    RUN_TEST_CASE( Full_TransportInterfaceTest, TransportRecv_NetworkContextNullPtr );
+    RUN_TEST_CASE( Full_TransportInterfaceTest, TransportRecv_BufferNullPtr );
+    RUN_TEST_CASE( Full_TransportInterfaceTest, TransportRecv_ZeroByteToRecv );
 
     /* Send and receive correctness test. */
     RUN_TEST_CASE( Full_TransportInterfaceTest, Transport_SendOneByteRecvCompare );

--- a/src/transport_interface/transport_interface_test.c
+++ b/src/transport_interface/transport_interface_test.c
@@ -64,6 +64,15 @@
       TRANSPORT_TEST_BUFFER_SUFFIX_GUARD_LENGTH )
 
 /**
+ * @brief Test invalid parameters with transport interface.
+ *
+ * These test cases are optional since they may required user to disable assertion.
+ */
+#ifndef TRANSPORT_TEST_INVALID_PARAMETERS
+    #define TRANSPORT_TEST_INVALID_PARAMETERS    ( 0 )
+#endif
+
+/**
  * @brief Transport Interface test buffer guard pattern.
  */
 #define TRANSPORT_TEST_BUFFER_GUARD_PATTERN        ( 0xA5 )
@@ -97,6 +106,32 @@
  */
 #define TRANSPORT_TEST_NETWORK_DELAY_MS            ( 3000U )
 
+/**
+ * @brief Number of simultaneous tasks for multithreaded tests.
+ */
+#define TRANSPORT_TEST_MULTI_THREAD_TASK_COUNT     ( 2U )
+
+/**
+ * @brief The thread parameter index used in non-multithreaded test.
+ */
+#define TRANSPORT_TEST_INDEX                       ( 0U )
+
+/**
+ * @brief Timeout to wait thread function finish the test.
+ */
+#ifndef TRANSPORT_TEST_WAIT_THREAD_TIMEOUT_MS
+    #define TRANSPORT_TEST_WAIT_THREAD_TIMEOUT_MS    ( 1000000U )
+#endif
+
+/*-----------------------------------------------------------*/
+
+typedef struct threadParameter
+{
+    NetworkContext_t * pNetworkContext;
+    uint8_t transportTestBuffer[ TRANSPORT_TEST_BUFFER_TOTAL_LENGTH ];
+    bool stopFlag;
+} threadParameter_t;
+
 /*-----------------------------------------------------------*/
 
 /**
@@ -115,9 +150,9 @@ static TestHostInfo_t testHostInfo = { 0 };
 static TransportInterface_t * pTestTransport = NULL;
 
 /**
- * @brief Test buffer used in tests.
+ * @brief Thread paramter to hold the network context and test buffer.
  */
-static uint8_t transportTestBuffer[ TRANSPORT_TEST_BUFFER_TOTAL_LENGTH ];
+static threadParameter_t threadParameter[ TRANSPORT_TEST_MULTI_THREAD_TASK_COUNT ];
 
 /**
  * @brief Test group for transport interface test.
@@ -165,10 +200,8 @@ static void prvVerifyTestData( uint8_t * pTransportTestBuffer,
     /* Check the buffer after testSize is unchanged. */
     if( testSize < maxBufferSize )
     {
-        TEST_ASSERT_EACH_EQUAL_HEX8_MESSAGE( TRANSPORT_TEST_BUFFER_GUARD_PATTERN,
-                                             &( pTransportTestBuffer[ testSize ] ),
-                                             ( maxBufferSize - testSize ),
-                                             "Buffer after testSize should not be altered." );
+        TEST_ASSERT_EQUAL_UINT8_MESSAGE( pTransportTestBuffer[ i ], TRANSPORT_TEST_BUFFER_GUARD_PATTERN,
+                                         "Buffer after testSize should not be altered." );
     }
 }
 
@@ -182,6 +215,7 @@ static void prvVerifyTestData( uint8_t * pTransportTestBuffer,
  * the API function. The retry operation is handled in this function.
  */
 static void prvTransportSendData( TransportInterface_t * pTransport,
+                                  NetworkContext_t * pNetworkContext,
                                   uint8_t * pTransportTestBuffer,
                                   uint32_t sendSize )
 {
@@ -191,7 +225,7 @@ static void prvTransportSendData( TransportInterface_t * pTransport,
 
     for( i = 0U; i < TRANSPORT_TEST_SEND_RECEIVE_RETRY_COUNT; i++ )
     {
-        transportResult = pTransport->send( pTransport->pNetworkContext,
+        transportResult = pTransport->send( pNetworkContext,
                                             &pTransportTestBuffer[ transferTotal ],
                                             sendSize - transferTotal );
         /* Send should not have any error. */
@@ -222,6 +256,7 @@ static void prvTransportSendData( TransportInterface_t * pTransport,
  * by calling the API function. The retry operation is handled in this function.
  */
 static void prvTransportRecvData( TransportInterface_t * pTransport,
+                                  NetworkContext_t * pNetworkContext,
                                   uint8_t * pTransportTestBuffer,
                                   uint32_t recvSize )
 {
@@ -234,7 +269,7 @@ static void prvTransportRecvData( TransportInterface_t * pTransport,
 
     for( i = 0U; i < TRANSPORT_TEST_SEND_RECEIVE_RETRY_COUNT; i++ )
     {
-        transportResult = pTransport->recv( pTransport->pNetworkContext,
+        transportResult = pTransport->recv( pNetworkContext,
                                             &pTransportTestBuffer[ transferTotal ],
                                             recvSize - transferTotal );
 
@@ -271,11 +306,71 @@ static void prvTransportRecvData( TransportInterface_t * pTransport,
 /*-----------------------------------------------------------*/
 
 /**
+ * @brief Verify the buffer guard of the test buffer.
+ */
+static void prvVerifyTestBufferGuard( uint8_t * pTransportTestBuffer )
+{
+    /* Prefix and Suffix guard buffers must never change. */
+    TEST_ASSERT_EACH_EQUAL_HEX8_MESSAGE( TRANSPORT_TEST_BUFFER_GUARD_PATTERN,
+                                         pTransportTestBuffer,
+                                         TRANSPORT_TEST_BUFFER_PREFIX_GUARD_LENGTH,
+                                         "transportTestBuffer prefix guard should not be altered." );
+    TEST_ASSERT_EACH_EQUAL_HEX8_MESSAGE( TRANSPORT_TEST_BUFFER_GUARD_PATTERN,
+                                         &( pTransportTestBuffer[ TRANSPORT_TEST_BUFFER_PREFIX_GUARD_LENGTH +
+                                                                  TRANSPORT_TEST_BUFFER_WRITABLE_LENGTH ] ),
+                                         TRANSPORT_TEST_BUFFER_SUFFIX_GUARD_LENGTH,
+                                         "transportTestBuffer suffix guard should not be altered." );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Thread function of the send/receive/compare test.
+ */
+static void prvSendRecvCompareFunc( void * pParam )
+{
+    threadParameter_t * pThreadParameter = pParam;
+    uint8_t * pTrasnportTestBufferStart =
+        &( pThreadParameter->transportTestBuffer[ TRANSPORT_TEST_BUFFER_PREFIX_GUARD_LENGTH ] );
+    uint32_t testBufferSize = 0;
+    NetworkContext_t * pNextworkContext = pThreadParameter->pNetworkContext;
+
+    for( testBufferSize = 1; testBufferSize <= TRANSPORT_TEST_BUFFER_WRITABLE_LENGTH; testBufferSize = testBufferSize + 1 )
+    {
+        /* Initialize the test data buffer. */
+        prvInitializeTestData( pTrasnportTestBufferStart, testBufferSize );
+
+        /* Send the test data to the server. */
+        prvTransportSendData( pTestTransport, pNextworkContext, pTrasnportTestBufferStart,
+                              testBufferSize );
+
+        /* Receive the test data from server. */
+        prvTransportRecvData( pTestTransport, pNextworkContext, pTrasnportTestBufferStart,
+                              testBufferSize );
+
+        /* Compare the test data received from server. */
+        prvVerifyTestData( pTrasnportTestBufferStart, testBufferSize, TRANSPORT_TEST_BUFFER_WRITABLE_LENGTH );
+
+        if( pThreadParameter->stopFlag == true )
+        {
+            break;
+        }
+
+        /* Output information to indicate the test is running. */
+        UNITY_OUTPUT_CHAR( '.' );
+    }
+}
+
+/*-----------------------------------------------------------*/
+
+/**
  * @brief Test setup function for transport interface test.
  */
 TEST_SETUP( Full_TransportInterfaceTest )
 {
     NetworkConnectStatus_t networkConnectResult = NETWORK_CONNECT_SUCCESS;
+    uint8_t * pTransportTestBuffer = threadParameter[ TRANSPORT_TEST_INDEX ].transportTestBuffer;
+    NetworkContext_t * pNetworkContext = threadParameter[ TRANSPORT_TEST_INDEX ].pNetworkContext;
 
     /* Ensure the tranpsort interface is valid. */
     TEST_ASSERT_NOT_NULL_MESSAGE( testParam.pTransport, "testParam.pTransport should not be NULL." );
@@ -285,14 +380,13 @@ TEST_SETUP( Full_TransportInterfaceTest )
     TEST_ASSERT_NOT_NULL_MESSAGE( testParam.pTransportTestDelay, "testParam.pTransportTestDelay should not be NULL." );
 
     /* Setup the trasnport structure to use the primary network context. */
-    testParam.pTransport->pNetworkContext = testParam.pNetworkContext;
     pTestTransport = testParam.pTransport;
 
     /* Initialize the transport test buffer with TRANSPORT_TEST_BUFFER_GUARD_PATTERN. */
-    memset( &( transportTestBuffer[ 0 ] ), TRANSPORT_TEST_BUFFER_GUARD_PATTERN, TRANSPORT_TEST_BUFFER_TOTAL_LENGTH );
+    memset( pTransportTestBuffer, TRANSPORT_TEST_BUFFER_GUARD_PATTERN, TRANSPORT_TEST_BUFFER_TOTAL_LENGTH );
 
     /* Call the hook function implemented by the application to initialize the transport interface. */
-    networkConnectResult = testParam.pNetworkConnect( pTestTransport->pNetworkContext,
+    networkConnectResult = testParam.pNetworkConnect( pNetworkContext,
                                                       &testHostInfo, testParam.pNetworkCredentials );
     TEST_ASSERT_EQUAL_INT32_MESSAGE( NETWORK_CONNECT_SUCCESS, networkConnectResult, "Network connect failed." );
 }
@@ -304,19 +398,13 @@ TEST_SETUP( Full_TransportInterfaceTest )
  */
 TEST_TEAR_DOWN( Full_TransportInterfaceTest )
 {
-    /* Prefix and Suffix guard buffers must never change. */
-    TEST_ASSERT_EACH_EQUAL_HEX8_MESSAGE( TRANSPORT_TEST_BUFFER_GUARD_PATTERN,
-                                         &( transportTestBuffer[ 0 ] ),
-                                         TRANSPORT_TEST_BUFFER_PREFIX_GUARD_LENGTH,
-                                         "transportTestBuffer prefix guard should not be altered." );
-    TEST_ASSERT_EACH_EQUAL_HEX8_MESSAGE( TRANSPORT_TEST_BUFFER_GUARD_PATTERN,
-                                         &( transportTestBuffer[ TRANSPORT_TEST_BUFFER_PREFIX_GUARD_LENGTH +
-                                                                 TRANSPORT_TEST_BUFFER_WRITABLE_LENGTH ] ),
-                                         TRANSPORT_TEST_BUFFER_SUFFIX_GUARD_LENGTH,
-                                         "transportTestBuffer suffix guard should not be altered." );
+    uint8_t * pTransportTestBuffer = threadParameter[ TRANSPORT_TEST_INDEX ].transportTestBuffer;
+    NetworkContext_t * pNetworkContext = threadParameter[ TRANSPORT_TEST_INDEX ].pNetworkContext;
+
+    prvVerifyTestBufferGuard( pTransportTestBuffer );
 
     /* Call the hook function implemented by the application to de-initialize the transport interface. */
-    testParam.pNetworkDisconnect( pTestTransport->pNetworkContext );
+    testParam.pNetworkDisconnect( pNetworkContext );
 }
 
 /*-----------------------------------------------------------*/
@@ -327,10 +415,11 @@ TEST_TEAR_DOWN( Full_TransportInterfaceTest )
 TEST( Full_TransportInterfaceTest, TransportSend_NetworkContextNullPtr )
 {
     int32_t sendResult = 0;
+    uint8_t * pTransportTestBuffer = threadParameter[ TRANSPORT_TEST_INDEX ].transportTestBuffer;
 
     /* Send with NULL network context pointer should return negative value. */
     sendResult = pTestTransport->send( NULL,
-                                       &( transportTestBuffer[ TRANSPORT_TEST_BUFFER_PREFIX_GUARD_LENGTH ] ),
+                                       &( pTransportTestBuffer[ TRANSPORT_TEST_BUFFER_PREFIX_GUARD_LENGTH ] ),
                                        TRANSPORT_TEST_BUFFER_WRITABLE_LENGTH );
     TEST_ASSERT_LESS_THAN_INT32_MESSAGE( 0, sendResult, "Transport interface send with NULL NetworkContext_t "
                                                         "pointer should return negative value." );
@@ -344,9 +433,10 @@ TEST( Full_TransportInterfaceTest, TransportSend_NetworkContextNullPtr )
 TEST( Full_TransportInterfaceTest, TransportSend_BufferNullPtr )
 {
     int32_t sendResult = 0;
+    NetworkContext_t * pNetworkContext = threadParameter[ TRANSPORT_TEST_INDEX ].pNetworkContext;
 
     /* Send with NULL buffer pointer should return negative value. */
-    sendResult = pTestTransport->send( pTestTransport->pNetworkContext, NULL, 1 );
+    sendResult = pTestTransport->send( pNetworkContext, NULL, 1 );
     TEST_ASSERT_LESS_THAN_INT32_MESSAGE( 0, sendResult, "Transport interface send with NULL buffer "
                                                         "pointer should return negative value." );
 }
@@ -359,10 +449,12 @@ TEST( Full_TransportInterfaceTest, TransportSend_BufferNullPtr )
 TEST( Full_TransportInterfaceTest, TransportSend_ZeroByteToSend )
 {
     int32_t sendResult = 0;
+    uint8_t * pTransportTestBuffer = threadParameter[ TRANSPORT_TEST_INDEX ].transportTestBuffer;
+    NetworkContext_t * pNetworkContext = threadParameter[ TRANSPORT_TEST_INDEX ].pNetworkContext;
 
     /* Send with zero byte to send should return negative value. */
-    sendResult = pTestTransport->send( pTestTransport->pNetworkContext,
-                                       &( transportTestBuffer[ TRANSPORT_TEST_BUFFER_PREFIX_GUARD_LENGTH ] ),
+    sendResult = pTestTransport->send( pNetworkContext,
+                                       &( pTransportTestBuffer[ TRANSPORT_TEST_BUFFER_PREFIX_GUARD_LENGTH ] ),
                                        0 );
     TEST_ASSERT_LESS_THAN_INT32_MESSAGE( 0, sendResult, "Transport interface send with zero byte "
                                                         "to send should return negative value." );
@@ -376,16 +468,17 @@ TEST( Full_TransportInterfaceTest, TransportSend_ZeroByteToSend )
 TEST( Full_TransportInterfaceTest, TransportRecv_NetworkContextNullPtr )
 {
     int32_t recvResult = 0;
+    uint8_t * pTransportTestBuffer = threadParameter[ TRANSPORT_TEST_INDEX ].transportTestBuffer;
 
     /* Receive with NULL network context pointer should return negative value. */
     recvResult = pTestTransport->recv( NULL,
-                                       &( transportTestBuffer[ TRANSPORT_TEST_BUFFER_PREFIX_GUARD_LENGTH ] ),
+                                       &( pTransportTestBuffer[ TRANSPORT_TEST_BUFFER_PREFIX_GUARD_LENGTH ] ),
                                        TRANSPORT_TEST_BUFFER_WRITABLE_LENGTH );
     TEST_ASSERT_LESS_THAN_INT32_MESSAGE( 0, recvResult, "Transport interface recv with NULL network "
                                                         "context pointer should return negative value." );
 
     TEST_ASSERT_EACH_EQUAL_HEX8_MESSAGE( TRANSPORT_TEST_BUFFER_GUARD_PATTERN,
-                                         &( transportTestBuffer[ TRANSPORT_TEST_BUFFER_PREFIX_GUARD_LENGTH ] ),
+                                         &( pTransportTestBuffer[ TRANSPORT_TEST_BUFFER_PREFIX_GUARD_LENGTH ] ),
                                          TRANSPORT_TEST_BUFFER_WRITABLE_LENGTH,
                                          "transportTestBuffer should not be altered." );
 }
@@ -398,10 +491,10 @@ TEST( Full_TransportInterfaceTest, TransportRecv_NetworkContextNullPtr )
 TEST( Full_TransportInterfaceTest, TransportRecv_BufferNullPtr )
 {
     int32_t recvResult = 0;
+    NetworkContext_t * pNetworkContext = threadParameter[ TRANSPORT_TEST_INDEX ].pNetworkContext;
 
     /* Receive with NULL buffer pointer should return negative value. */
-    recvResult = pTestTransport->recv( pTestTransport->pNetworkContext, NULL,
-                                       TRANSPORT_TEST_BUFFER_WRITABLE_LENGTH );
+    recvResult = pTestTransport->recv( pNetworkContext, NULL, TRANSPORT_TEST_BUFFER_WRITABLE_LENGTH );
     TEST_ASSERT_LESS_THAN_INT32_MESSAGE( 0, recvResult, "Transport interface recv with NULL buffer "
                                                         "pointer should return negative value." );
 }
@@ -414,16 +507,18 @@ TEST( Full_TransportInterfaceTest, TransportRecv_BufferNullPtr )
 TEST( Full_TransportInterfaceTest, TransportRecv_ZeroByteToRecv )
 {
     int32_t recvResult = 0;
+    uint8_t * pTransportTestBuffer = threadParameter[ TRANSPORT_TEST_INDEX ].transportTestBuffer;
+    NetworkContext_t * pNetworkContext = threadParameter[ TRANSPORT_TEST_INDEX ].pNetworkContext;
 
     /* Receive with zero byte to recv should return negative value. */
-    recvResult = pTestTransport->recv( pTestTransport->pNetworkContext,
-                                       &( transportTestBuffer[ TRANSPORT_TEST_BUFFER_PREFIX_GUARD_LENGTH ] ),
+    recvResult = pTestTransport->recv( pNetworkContext,
+                                       &( pTransportTestBuffer[ TRANSPORT_TEST_BUFFER_PREFIX_GUARD_LENGTH ] ),
                                        0 );
     TEST_ASSERT_LESS_THAN_INT32_MESSAGE( 0, recvResult, "Transport interface recv with zero "
                                                         "byte to recv should return negative value." );
 
     TEST_ASSERT_EACH_EQUAL_HEX8_MESSAGE( TRANSPORT_TEST_BUFFER_GUARD_PATTERN,
-                                         &( transportTestBuffer[ TRANSPORT_TEST_BUFFER_PREFIX_GUARD_LENGTH ] ),
+                                         &( pTransportTestBuffer[ TRANSPORT_TEST_BUFFER_PREFIX_GUARD_LENGTH ] ),
                                          TRANSPORT_TEST_BUFFER_WRITABLE_LENGTH,
                                          "transportTestBuffer should not be altered." );
 }
@@ -431,35 +526,43 @@ TEST( Full_TransportInterfaceTest, TransportRecv_ZeroByteToRecv )
 /*-----------------------------------------------------------*/
 
 /**
- * @brief Test transport interface with send, receive and compare on one byte.
+ * @brief Test transport interface with send one byte, receive and compare
  *
  * Test send receive beharivor in the following order.
- * Send : 1 bytes
- * Receive : 1 byte
+ * Send : 1 byte
+ * Send : ( TRANSPORT_TEST_BUFFER_WRITABLE_LENGTH - 1 ) bytes
+ * Receive : TRANSPORT_TEST_BUFFER_WRITABLE_LENGTH bytes
  */
 TEST( Full_TransportInterfaceTest, Transport_SendOneByteRecvCompare )
 {
     /* Pointer of writable test buffer. */
     uint8_t * pTrasnportTestBufferStart =
-        &( transportTestBuffer[ TRANSPORT_TEST_BUFFER_PREFIX_GUARD_LENGTH ] );
+        &( threadParameter[ TRANSPORT_TEST_INDEX ].transportTestBuffer[ TRANSPORT_TEST_BUFFER_PREFIX_GUARD_LENGTH ] );
+    NetworkContext_t * pNetworkContext = threadParameter[ TRANSPORT_TEST_INDEX ].pNetworkContext;
 
     /* Initialize the test data buffer. */
-    prvInitializeTestData( pTrasnportTestBufferStart, 1U );
+    prvInitializeTestData( pTrasnportTestBufferStart, TRANSPORT_TEST_BUFFER_WRITABLE_LENGTH );
 
     /* Send the test data to the server. */
-    prvTransportSendData( pTestTransport, pTrasnportTestBufferStart, 1U );
+    prvTransportSendData( pTestTransport, pNetworkContext, pTrasnportTestBufferStart, 1U );
+
+    /* Send the rest test data to the server. */
+    prvTransportSendData( pTestTransport, pNetworkContext, &pTrasnportTestBufferStart[ 1 ],
+                          ( TRANSPORT_TEST_BUFFER_WRITABLE_LENGTH - 1U ) );
 
     /* Receive the test data from server. */
-    prvTransportRecvData( pTestTransport, pTrasnportTestBufferStart, 1U );
+    prvTransportRecvData( pTestTransport, pNetworkContext, pTrasnportTestBufferStart,
+                          TRANSPORT_TEST_BUFFER_WRITABLE_LENGTH );
 
     /* Compare the test data received from server. */
-    prvVerifyTestData( pTrasnportTestBufferStart, 1U, TRANSPORT_TEST_BUFFER_WRITABLE_LENGTH );
+    prvVerifyTestData( pTrasnportTestBufferStart, TRANSPORT_TEST_BUFFER_WRITABLE_LENGTH,
+                       TRANSPORT_TEST_BUFFER_WRITABLE_LENGTH );
 }
 
 /*-----------------------------------------------------------*/
 
 /**
- * @brief Test transport interface with send, receive and compare.
+ * @brief Test transport interface with send, receive one byte and compare.
  *
  * Test send receive beharivor in the following order.
  * Send : TRANSPORT_TEST_BUFFER_WRITABLE_LENGTH bytes
@@ -470,26 +573,27 @@ TEST( Full_TransportInterfaceTest, Transport_SendRecvOneByteCompare )
 {
     /* Pointer of writable test buffer. */
     uint8_t * pTrasnportTestBufferStart =
-        &( transportTestBuffer[ TRANSPORT_TEST_BUFFER_PREFIX_GUARD_LENGTH ] );
+        &( threadParameter[ TRANSPORT_TEST_INDEX ].transportTestBuffer[ TRANSPORT_TEST_BUFFER_PREFIX_GUARD_LENGTH ] );
+    NetworkContext_t * pNetworkContext = threadParameter[ TRANSPORT_TEST_INDEX ].pNetworkContext;
 
     /* Initialize the test data buffer. */
     prvInitializeTestData( pTrasnportTestBufferStart, TRANSPORT_TEST_BUFFER_WRITABLE_LENGTH );
 
     /* Send the test data to the server. */
-    prvTransportSendData( pTestTransport, pTrasnportTestBufferStart,
+    prvTransportSendData( pTestTransport, pNetworkContext, pTrasnportTestBufferStart,
                           TRANSPORT_TEST_BUFFER_WRITABLE_LENGTH );
 
     /* Reset the buffer. The buffer after received data is verified in prvVerifyTestData. */
     memset( pTrasnportTestBufferStart, TRANSPORT_TEST_BUFFER_GUARD_PATTERN, TRANSPORT_TEST_BUFFER_WRITABLE_LENGTH );
 
     /* Receive one byte test data from server. */
-    prvTransportRecvData( pTestTransport, pTrasnportTestBufferStart, 1U );
+    prvTransportRecvData( pTestTransport, pNetworkContext, pTrasnportTestBufferStart, 1U );
 
     /* Compare the test data received from server. */
     prvVerifyTestData( pTrasnportTestBufferStart, 1U, TRANSPORT_TEST_BUFFER_WRITABLE_LENGTH );
 
     /* Receive remain test data from server. */
-    prvTransportRecvData( pTestTransport, &pTrasnportTestBufferStart[ 1U ],
+    prvTransportRecvData( pTestTransport, pNetworkContext, &pTrasnportTestBufferStart[ 1U ],
                           ( TRANSPORT_TEST_BUFFER_WRITABLE_LENGTH - 1U ) );
 
     /* Compare remain test data received from server. */
@@ -501,31 +605,71 @@ TEST( Full_TransportInterfaceTest, Transport_SendRecvOneByteCompare )
 
 /**
  * @brief Test transport interface with send, receive and compare on variable length.
- *
- * Test send receive beharivor in the following order.
- * Send : TRANSPORT_TEST_BUFFER_WRITABLE_LENGTH bytes
- * Receive : TRANSPORT_TEST_BUFFER_WRITABLE_LENGTH bytes
  */
 TEST( Full_TransportInterfaceTest, Transport_SendRecvCompare )
 {
-    /* Pointer of writable test buffer. */
-    uint8_t * pTrasnportTestBufferStart =
-        &( transportTestBuffer[ TRANSPORT_TEST_BUFFER_PREFIX_GUARD_LENGTH ] );
+    prvSendRecvCompareFunc( &threadParameter[ TRANSPORT_TEST_INDEX ] );
+}
 
-    /* Initialize the test data buffer. */
-    prvInitializeTestData( pTrasnportTestBufferStart, TRANSPORT_TEST_BUFFER_WRITABLE_LENGTH );
+/*-----------------------------------------------------------*/
 
-    /* Send the test data to the server. */
-    prvTransportSendData( pTestTransport, pTrasnportTestBufferStart,
-                          TRANSPORT_TEST_BUFFER_WRITABLE_LENGTH );
+/**
+ * @brief Test transport interface with send, receive and compare on variable length in multiple threads.
+ */
+TEST( Full_TransportInterfaceTest, Transport_SendRecvCompareMultithreaded )
+{
+    NetworkConnectStatus_t networkConnectResult = NETWORK_CONNECT_SUCCESS;
+    int timedWaitResult = 0;
+    TestThreadHandle_t threadHandle[ TRANSPORT_TEST_MULTI_THREAD_TASK_COUNT ];
+    uint32_t threadIndex = 0;
 
-    /* Receive the test data from server. */
-    prvTransportRecvData( pTestTransport, pTrasnportTestBufferStart,
-                          TRANSPORT_TEST_BUFFER_WRITABLE_LENGTH );
+    /* The primary thread parameter already setup in the test setup function. */
+    for( threadIndex = 1; threadIndex < TRANSPORT_TEST_MULTI_THREAD_TASK_COUNT; threadIndex++ )
+    {
+        memset( threadParameter[ 1 ].transportTestBuffer,
+                TRANSPORT_TEST_BUFFER_GUARD_PATTERN, TRANSPORT_TEST_BUFFER_TOTAL_LENGTH );
+    }
 
-    /* Compare the test data received from server. */
-    prvVerifyTestData( pTrasnportTestBufferStart, TRANSPORT_TEST_BUFFER_WRITABLE_LENGTH,
-                       TRANSPORT_TEST_BUFFER_WRITABLE_LENGTH );
+    /* Connect the secondary network context. */
+    networkConnectResult = testParam.pNetworkConnect( testParam.pSecondNetworkContext,
+                                                      &testHostInfo, testParam.pNetworkCredentials );
+    TEST_ASSERT_EQUAL_INT32_MESSAGE( NETWORK_CONNECT_SUCCESS, networkConnectResult, "Network connect failed." );
+
+    /* Create testing threads. */
+    for( threadIndex = 0; threadIndex < TRANSPORT_TEST_MULTI_THREAD_TASK_COUNT; threadIndex++ )
+    {
+        threadParameter[ threadIndex ].stopFlag = false;
+        threadHandle[ threadIndex ] = testParam.pTestThreadCreate( prvSendRecvCompareFunc,
+                                                                   &threadParameter[ threadIndex ] );
+        TEST_ASSERT_MESSAGE( threadHandle != NULL, "Create thread failed" );
+    }
+
+    /* Waiting for all the test thread complete. */
+    for( threadIndex = 0; threadIndex < TRANSPORT_TEST_MULTI_THREAD_TASK_COUNT; threadIndex++ )
+    {
+        timedWaitResult = testParam.pTestThreadTimedWait( threadHandle[ threadIndex ],
+                                                          TRANSPORT_TEST_WAIT_THREAD_TIMEOUT_MS );
+
+        if( timedWaitResult != 0 )
+        {
+            threadParameter[ threadIndex ].stopFlag = true;
+        }
+    }
+
+    /* The primary thread network context will be closed in the test shutdown function. */
+    for( threadIndex = 1; threadIndex < TRANSPORT_TEST_MULTI_THREAD_TASK_COUNT; threadIndex++ )
+    {
+        testParam.pNetworkDisconnect( threadParameter[ threadIndex ].pNetworkContext );
+
+        /* Check the test buffer guard. */
+        prvVerifyTestBufferGuard( threadParameter[ threadIndex ].transportTestBuffer );
+    }
+
+    /* Check if every thread finish the test in time. */
+    for( threadIndex = 0; threadIndex < TRANSPORT_TEST_MULTI_THREAD_TASK_COUNT; threadIndex++ )
+    {
+        TEST_ASSERT_MESSAGE( threadParameter[ threadIndex ].stopFlag != true, "Test thread timeout." );
+    }
 }
 
 /*-----------------------------------------------------------*/
@@ -538,7 +682,7 @@ TEST( Full_TransportInterfaceTest, TransportSend_RemoteDisconnect )
     int32_t transportResult = 0;
 
     uint8_t * pTrasnportTestBufferStart =
-        &( transportTestBuffer[ TRANSPORT_TEST_BUFFER_PREFIX_GUARD_LENGTH ] );
+        &( threadParameter[ TRANSPORT_TEST_INDEX ].transportTestBuffer[ TRANSPORT_TEST_BUFFER_PREFIX_GUARD_LENGTH ] );
 
     /* Send the disconnect command to remote server. */
     transportResult = pTestTransport->send( pTestTransport->pNetworkContext,
@@ -568,7 +712,7 @@ TEST( Full_TransportInterfaceTest, TransportRecv_RemoteDisconnect )
     int32_t transportResult = 0;
 
     uint8_t * pTrasnportTestBufferStart =
-        &( transportTestBuffer[ TRANSPORT_TEST_BUFFER_PREFIX_GUARD_LENGTH ] );
+        &( threadParameter[ TRANSPORT_TEST_INDEX ].transportTestBuffer[ TRANSPORT_TEST_BUFFER_PREFIX_GUARD_LENGTH ] );
 
     /* Send the disconnect command to remote server. */
     transportResult = pTestTransport->send( pTestTransport->pNetworkContext,
@@ -589,7 +733,7 @@ TEST( Full_TransportInterfaceTest, TransportRecv_RemoteDisconnect )
 
     /* The buffer should remain unchanged when negative value returned. */
     TEST_ASSERT_EACH_EQUAL_HEX8_MESSAGE( TRANSPORT_TEST_BUFFER_GUARD_PATTERN,
-                                         &( transportTestBuffer[ TRANSPORT_TEST_BUFFER_PREFIX_GUARD_LENGTH ] ),
+                                         pTrasnportTestBufferStart,
                                          TRANSPORT_TEST_BUFFER_WRITABLE_LENGTH,
                                          "transportTestBuffer should not be altered." );
 }
@@ -604,17 +748,18 @@ TEST( Full_TransportInterfaceTest, TransportRecv_NoDataToReceive )
     int32_t transportResult = 0;
     /* Pointer of writable test buffer. */
     uint8_t * pTrasnportTestBufferStart =
-        &( transportTestBuffer[ TRANSPORT_TEST_BUFFER_PREFIX_GUARD_LENGTH ] );
+        &( threadParameter[ TRANSPORT_TEST_INDEX ].transportTestBuffer[ TRANSPORT_TEST_BUFFER_PREFIX_GUARD_LENGTH ] );
+    NetworkContext_t * pNetworkContext = threadParameter[ TRANSPORT_TEST_INDEX ].pNetworkContext;
 
     /* Receive from remote server. No data will be recevied since no data is sent. */
-    transportResult = pTestTransport->recv( pTestTransport->pNetworkContext,
+    transportResult = pTestTransport->recv( pNetworkContext,
                                             pTrasnportTestBufferStart,
                                             TRANSPORT_TEST_BUFFER_WRITABLE_LENGTH );
     TEST_ASSERT_EQUAL_INT32_MESSAGE( 0, transportResult, "No data to receive should return 0." );
 
     /* The buffer should remain unchanged when zero returned. */
     TEST_ASSERT_EACH_EQUAL_HEX8_MESSAGE( TRANSPORT_TEST_BUFFER_GUARD_PATTERN,
-                                         &( transportTestBuffer[ TRANSPORT_TEST_BUFFER_PREFIX_GUARD_LENGTH ] ),
+                                         pTrasnportTestBufferStart,
                                          TRANSPORT_TEST_BUFFER_WRITABLE_LENGTH,
                                          "transportTestBuffer should not be altered." );
 }
@@ -631,20 +776,20 @@ TEST( Full_TransportInterfaceTest, TransportRecv_NoDataToReceive )
 TEST( Full_TransportInterfaceTest, TransportRecv_ReturnZeroRetry )
 {
     int32_t transportResult = 0;
-    uint32_t transportSendTotal = 0, transportRecvTotal = 0;
     /* Pointer of writable test buffer. */
     uint8_t * pTrasnportTestBufferStart =
-        &( transportTestBuffer[ TRANSPORT_TEST_BUFFER_PREFIX_GUARD_LENGTH ] );
+        &( threadParameter[ TRANSPORT_TEST_INDEX ].transportTestBuffer[ TRANSPORT_TEST_BUFFER_PREFIX_GUARD_LENGTH ] );
+    NetworkContext_t * pNetworkContext = threadParameter[ TRANSPORT_TEST_INDEX ].pNetworkContext;
 
     /* Receive from remote server. No data will be recevied since no data is sent. */
-    transportResult = pTestTransport->recv( pTestTransport->pNetworkContext,
+    transportResult = pTestTransport->recv( pNetworkContext,
                                             pTrasnportTestBufferStart,
                                             TRANSPORT_TEST_BUFFER_WRITABLE_LENGTH );
     TEST_ASSERT_EQUAL_INT32_MESSAGE( 0, transportResult, "No data to receive should return 0." );
 
     /* The buffer should remain unchanged when zero returned. */
     TEST_ASSERT_EACH_EQUAL_HEX8_MESSAGE( TRANSPORT_TEST_BUFFER_GUARD_PATTERN,
-                                         &( transportTestBuffer[ TRANSPORT_TEST_BUFFER_PREFIX_GUARD_LENGTH ] ),
+                                         pTrasnportTestBufferStart,
                                          TRANSPORT_TEST_BUFFER_WRITABLE_LENGTH,
                                          "transportTestBuffer should not be altered." );
 
@@ -652,10 +797,10 @@ TEST( Full_TransportInterfaceTest, TransportRecv_ReturnZeroRetry )
     prvInitializeTestData( pTrasnportTestBufferStart, 1U );
 
     /* Send the test data to the server. */
-    prvTransportSendData( pTestTransport, pTrasnportTestBufferStart, 1U );
+    prvTransportSendData( pTestTransport, pNetworkContext, pTrasnportTestBufferStart, 1U );
 
     /* Receive the test data from server. */
-    prvTransportRecvData( pTestTransport, pTrasnportTestBufferStart, 1U );
+    prvTransportRecvData( pTestTransport, pNetworkContext, pTrasnportTestBufferStart, 1U );
 
     /* Compare the test data received from server. */
     prvVerifyTestData( pTrasnportTestBufferStart, 1U, TRANSPORT_TEST_BUFFER_WRITABLE_LENGTH );
@@ -668,18 +813,21 @@ TEST( Full_TransportInterfaceTest, TransportRecv_ReturnZeroRetry )
  */
 TEST_GROUP_RUNNER( Full_TransportInterfaceTest )
 {
-    /* Invalid parameter test. */
-    RUN_TEST_CASE( Full_TransportInterfaceTest, TransportSend_NetworkContextNullPtr );
-    RUN_TEST_CASE( Full_TransportInterfaceTest, TransportSend_BufferNullPtr );
-    RUN_TEST_CASE( Full_TransportInterfaceTest, TransportSend_ZeroByteToSend );
-    RUN_TEST_CASE( Full_TransportInterfaceTest, TransportRecv_NetworkContextNullPtr );
-    RUN_TEST_CASE( Full_TransportInterfaceTest, TransportRecv_BufferNullPtr );
-    RUN_TEST_CASE( Full_TransportInterfaceTest, TransportRecv_ZeroByteToRecv );
+    /* Optional invalid parameter tests. Disable assertion may be required to run these tests. */
+    #if ( TRANSPORT_TEST_INVALID_PARAMETERS == 1 )
+        RUN_TEST_CASE( Full_TransportInterfaceTest, TransportSend_NetworkContextNullPtr );
+        RUN_TEST_CASE( Full_TransportInterfaceTest, TransportSend_BufferNullPtr );
+        RUN_TEST_CASE( Full_TransportInterfaceTest, TransportSend_ZeroByteToSend );
+        RUN_TEST_CASE( Full_TransportInterfaceTest, TransportRecv_NetworkContextNullPtr );
+        RUN_TEST_CASE( Full_TransportInterfaceTest, TransportRecv_BufferNullPtr );
+        RUN_TEST_CASE( Full_TransportInterfaceTest, TransportRecv_ZeroByteToRecv );
+    #endif
 
     /* Send and receive correctness test. */
     RUN_TEST_CASE( Full_TransportInterfaceTest, Transport_SendOneByteRecvCompare );
     RUN_TEST_CASE( Full_TransportInterfaceTest, Transport_SendRecvOneByteCompare );
     RUN_TEST_CASE( Full_TransportInterfaceTest, Transport_SendRecvCompare );
+    RUN_TEST_CASE( Full_TransportInterfaceTest, Transport_SendRecvCompareMultithreaded );
 
     /* Disconnect test. */
     RUN_TEST_CASE( Full_TransportInterfaceTest, TransportSend_RemoteDisconnect );
@@ -699,6 +847,8 @@ int RunTransportInterfaceTest( void )
     #if ( TRANSPORT_INTERFACE_TEST_ENABLED == 1 )
         /* Assign the TransportInterface_t pointer used in test cases. */
         SetupTransportTestParam( &testParam );
+        threadParameter[ 0 ].pNetworkContext = testParam.pNetworkContext;
+        threadParameter[ 1 ].pNetworkContext = testParam.pSecondNetworkContext;
         testHostInfo.pHostName = ECHO_SERVER_ENDPOINT;
         testHostInfo.port = ECHO_SERVER_PORT;
 

--- a/src/transport_interface/transport_interface_test.h
+++ b/src/transport_interface/transport_interface_test.h
@@ -33,64 +33,26 @@
 /* Include for network connection. */
 #include "network_connection.h"
 
+/* Include for thread function. */
+#include "thread_function.h"
+
 /* Include for transport interface. */
 #include "transport_interface.h"
-
-/**
- * @brief Thread handle data structure definition.
- */
-typedef void * TestThreadHandle_t;
-
-/**
- * @brief Thread function to be executed in ThreadCreate_t function.
- *
- * @param[in] pParam The pParam parameter passed in ThreadCreate_t function.
- */
-typedef void ( * TestThreadFunction_t )( void * pParam );
-
-/**
- * @brief Thread create function for core PKCS11 test.
- *
- * @param[in] threadFunc The thread function to be executed in the created thread.
- * @param[in] pParam The pParam parameter passed to the thread function pParam parameter.
- *
- * @return NULL if create thread failed. Otherwise, return the handle of the created thread.
- */
-typedef TestThreadHandle_t ( * TestThreadCreate_t )( TestThreadFunction_t threadFunc,
-                                                     void * pParam );
-
-/**
- * @brief Timed waiting function to wait for the created thread exit.
- *
- * @param[in] threadHandle The handle of the created thread to be waited.
- * @param[in] timeoutMs The timeout value of to wait for the created thread exit.
- *
- * @return 0 if the thread exits within timeoutMs. Other value will be regarded as error.
- */
-typedef int ( * TestThreadTimedWait_t )( TestThreadHandle_t threadHandle,
-                                         uint32_t timeoutMs );
-
-/**
- * @brief Delay function to wait for the data transfer over transport network.
- *
- * @param[in] delayMs Delay in milliseconds.
- */
-typedef void (* TransportTestDelayFunc_t )( uint32_t delayMs );
 
 /**
  * @brief A struct representing transport interface test parameters.
  */
 typedef struct TransportTestParam
 {
-    TransportInterface_t * pTransport;            /**< @brief Transport interface structure to test. */
-    NetworkConnectFunc_t pNetworkConnect;         /**< @brief Network connect function pointer. */
-    NetworkDisconnectFunc_t pNetworkDisconnect;   /**< @brief Network disconnect function pointer. */
-    TransportTestDelayFunc_t pTransportTestDelay; /**< @brief Transport test delay function pointer. */
-    TestThreadCreate_t pTestThreadCreate;         /**< @brief Test thread create function. */
-    TestThreadTimedWait_t pTestThreadTimedWait;   /**< @brief Test thread timed wait function. */
-    void * pNetworkCredentials;                   /**< @brief Network credentials for network connection. */
-    void * pNetworkContext;                       /**< @brief Primary network context. */
-    void * pSecondNetworkContext;                 /**< @brief Secondary network context. */
+    TransportInterface_t * pTransport;          /**< @brief Transport interface structure to test. */
+    NetworkConnectFunc_t pNetworkConnect;       /**< @brief Network connect function pointer. */
+    NetworkDisconnectFunc_t pNetworkDisconnect; /**< @brief Network disconnect function pointer. */
+    ThreadDelayFunc_t pThreadDelay;             /**< @brief Transport test delay function pointer. */
+    ThreadCreate_t pThreadCreate;               /**< @brief Test thread create function. */
+    ThreadTimedWait_t pThreadTimedWait;         /**< @brief Test thread timed wait function. */
+    void * pNetworkCredentials;                 /**< @brief Network credentials for network connection. */
+    void * pNetworkContext;                     /**< @brief Primary network context. */
+    void * pSecondNetworkContext;               /**< @brief Secondary network context. */
 } TransportTestParam_t;
 
 /**

--- a/src/transport_interface/transport_interface_test.h
+++ b/src/transport_interface/transport_interface_test.h
@@ -37,6 +37,40 @@
 #include "transport_interface.h"
 
 /**
+ * @brief Thread handle data structure definition.
+ */
+typedef void * TestThreadHandle_t;
+
+/**
+ * @brief Thread function to be executed in ThreadCreate_t function.
+ *
+ * @param[in] pParam The pParam parameter passed in ThreadCreate_t function.
+ */
+typedef void ( * TestThreadFunction_t )( void * pParam );
+
+/**
+ * @brief Thread create function for core PKCS11 test.
+ *
+ * @param[in] threadFunc The thread function to be executed in the created thread.
+ * @param[in] pParam The pParam parameter passed to the thread function pParam parameter.
+ *
+ * @return NULL if create thread failed. Otherwise, return the handle of the created thread.
+ */
+typedef TestThreadHandle_t ( * TestThreadCreate_t )( TestThreadFunction_t threadFunc,
+                                                     void * pParam );
+
+/**
+ * @brief Timed waiting function to wait for the created thread exit.
+ *
+ * @param[in] threadHandle The handle of the created thread to be waited.
+ * @param[in] timeoutMs The timeout value of to wait for the created thread exit.
+ *
+ * @return 0 if the thread exits within timeoutMs. Other value will be regarded as error.
+ */
+typedef int ( * TestThreadTimedWait_t )( TestThreadHandle_t threadHandle,
+                                         uint32_t timeoutMs );
+
+/**
  * @brief Delay function to wait for the data transfer over transport network.
  *
  * @param[in] delayMs Delay in milliseconds.
@@ -52,8 +86,11 @@ typedef struct TransportTestParam
     NetworkConnectFunc_t pNetworkConnect;         /**< @brief Network connect function pointer. */
     NetworkDisconnectFunc_t pNetworkDisconnect;   /**< @brief Network disconnect function pointer. */
     TransportTestDelayFunc_t pTransportTestDelay; /**< @brief Transport test delay function pointer. */
+    TestThreadCreate_t pTestThreadCreate;         /**< @brief Test thread create function. */
+    TestThreadTimedWait_t pTestThreadTimedWait;   /**< @brief Test thread timed wait function. */
     void * pNetworkCredentials;                   /**< @brief Network credentials for network connection. */
     void * pNetworkContext;                       /**< @brief Primary network context. */
+    void * pSecondNetworkContext;                 /**< @brief Secondary network context. */
 } TransportTestParam_t;
 
 /**


### PR DESCRIPTION
Update the transport interface test cases
* Update "SendRecvCompare" test case. Data size ranges from 1 - TRANSPORT_TEST_BUFFER_WRITABLE_LENGTH. The test case may take up to 10 minutes to complete the test. “...” log output to indicate the test is still running.
* Add Multithreaded test case, "SendRecvCompareMultithreaded". 
* Use test thread to detect transport interface blocking when no data to receive in “NoDataToReceive” and “ReturnZeroRetry” test cases.
* Makes invalid parameter tests optional.