### PR TITLE
Mqtt Test Updates

### DIFF
--- a/config_template/test_param_config_template.h
+++ b/config_template/test_param_config_template.h
@@ -51,6 +51,42 @@
  */
 
 /**
+ * @brief Root certificate of the IoT Core.
+ *
+ * @note This certificate should be PEM-encoded.
+ *
+ * Must include the PEM header and footer:
+ * "-----BEGIN CERTIFICATE-----\n"\
+ * "...base64 data...\n"\
+ * "-----END CERTIFICATE-----\n"
+ *
+ * #define IOT_CORE_ROOT_CA NULL
+ */
+
+/**
+ * @brief Client certificate to connect to MQTT server.
+ *
+ * @note This certificate should be PEM-encoded.
+ *
+ * Must include the PEM header and footer:
+ * "-----BEGIN CERTIFICATE-----\n"\
+ * "...base64 data...\n"\
+ * "-----END CERTIFICATE-----\n"
+ *
+ * #define MQTT_CLIENT_CERTIFICATE NULL
+ */
+
+/**
+ * @brief Client private key to connect to MQTT server.
+ *
+ * @note This is should only be used for testing purpose.
+ *
+ * For qualification, the key should be generated on-device.
+ *
+ * #define MQTT_CLIENT_PRIVATE_KEY  NULL
+ */
+
+/**
  * @brief Endpoint of the echo server to connect to in transport interface test.
  *
  * #define ECHO_SERVER_ENDPOINT   "PLACE_HOLDER"

--- a/src/mqtt/mqtt_test.c
+++ b/src/mqtt/mqtt_test.c
@@ -89,9 +89,9 @@
 #define TEST_MQTT_TOPIC                         CLIENT_IDENTIFIER "/iot/integration/test"
 
 /**
- * @brief Sample topic filter 2 to use in tests.
+ * @brief Sample topic filter to test MQTT retainted message.
  */
-#define TEST_MQTT_TOPIC_2                       CLIENT_IDENTIFIER "/iot/integration/test2"
+#define TEST_MQTT_RETAIN_TOPIC                  CLIENT_IDENTIFIER "/iot/integration/testretain"
 
 /**
  * @brief Length of sample topic filter.
@@ -1143,7 +1143,7 @@ TEST( MqttTest, MQTT_Publish_With_Retain_Flag )
 {
     /* Publish to a topic with the "retain" flag set. */
     TEST_ASSERT_EQUAL( MQTTSuccess, publishToTopic( &context,
-                                                    TEST_MQTT_TOPIC,
+                                                    TEST_MQTT_RETAIN_TOPIC,
                                                     true,  /* setRetainFlag */
                                                     false, /* isDuplicate */
                                                     MQTTQoS1,
@@ -1157,7 +1157,7 @@ TEST( MqttTest, MQTT_Publish_With_Retain_Flag )
     /* Subscribe to the same topic that we published the message to.
      * The broker should send the "retained" message with the "retain" flag set. */
     TEST_ASSERT_EQUAL( MQTTSuccess, subscribeToTopic(
-                           &context, TEST_MQTT_TOPIC, MQTTQoS1 ) );
+                           &context, TEST_MQTT_RETAIN_TOPIC, MQTTQoS1 ) );
     TEST_ASSERT_FALSE( receivedSubAck );
     TEST_ASSERT_EQUAL( MQTTSuccess,
                        MQTT_ProcessLoop( &context, 2 * MQTT_PROCESS_LOOP_TIMEOUT_MS ) );
@@ -1175,7 +1175,7 @@ TEST( MqttTest, MQTT_Publish_With_Retain_Flag )
 
     /* Publish to another topic with the "retain" flag set to 0. */
     TEST_ASSERT_EQUAL( MQTTSuccess, publishToTopic( &context,
-                                                    TEST_MQTT_TOPIC_2,
+                                                    TEST_MQTT_TOPIC,
                                                     false, /* setRetainFlag */
                                                     false, /* isDuplicate */
                                                     MQTTQoS1,
@@ -1191,7 +1191,7 @@ TEST( MqttTest, MQTT_Publish_With_Retain_Flag )
      * We don't expect the broker to send the message to us (as we
      * PUBLISHed without a retain flag set). */
     TEST_ASSERT_EQUAL( MQTTSuccess, subscribeToTopic(
-                           &context, TEST_MQTT_TOPIC_2, MQTTQoS1 ) );
+                           &context, TEST_MQTT_TOPIC, MQTTQoS1 ) );
     TEST_ASSERT_FALSE( receivedSubAck );
     TEST_ASSERT_EQUAL( MQTTSuccess,
                        MQTT_ProcessLoop( &context, 2 * MQTT_PROCESS_LOOP_TIMEOUT_MS ) );


### PR DESCRIPTION
This PR made two changes to MQTT tests.
1. Fixed an issue with retained message test. Previously retained message test uses the same topic as other test. As a result MQTT_Subscribe_Publish_With_Qos_0 and MQTT_Subscribe_Publish_With_Qos_1 would receive a retained message when they subscribe to the topic, before the test cases make publishes. This PR fixed the issue by using a dedicated topic for retained message test.
2. Updated config template with MQTT credential options.