### PR TITLE
Param checking and documentation update

### DIFF
--- a/src/mqtt/mqtt_test.c
+++ b/src/mqtt/mqtt_test.c
@@ -169,6 +169,16 @@
 
 /*-----------------------------------------------------------*/
 
+#ifndef MQTT_SERVER_ENDPOINT
+    #error "Please define MQTT_SERVER_ENDPOINT"
+#endif
+
+#ifndef MQTT_SERVER_PORT
+    #error "Please define MQTT_SERVER_PORT"
+#endif
+
+/*-----------------------------------------------------------*/
+
 /**
  * @brief a struct of test parameters filled in by user.
  */

--- a/src/mqtt/mqtt_test.c
+++ b/src/mqtt/mqtt_test.c
@@ -169,13 +169,15 @@
 
 /*-----------------------------------------------------------*/
 
-#ifndef MQTT_SERVER_ENDPOINT
-    #error "Please define MQTT_SERVER_ENDPOINT"
-#endif
-
-#ifndef MQTT_SERVER_PORT
-    #error "Please define MQTT_SERVER_PORT"
-#endif
+#if ( MQTT_TEST_ENABLED == 1 )
+    #ifndef MQTT_SERVER_ENDPOINT
+        #error "Please define MQTT_SERVER_ENDPOINT"
+    #endif
+    
+    #ifndef MQTT_SERVER_PORT
+        #error "Please define MQTT_SERVER_PORT"
+    #endif
+#endif /* if ( MQTT_TEST_ENABLED == 1 ) */
 
 /*-----------------------------------------------------------*/
 

--- a/src/transport_interface/transport_interface_test.c
+++ b/src/transport_interface/transport_interface_test.c
@@ -99,13 +99,15 @@
 
 /*-----------------------------------------------------------*/
 
-#ifndef ECHO_SERVER_ENDPOINT
-    #error "Please define ECHO_SERVER_ENDPOINT"
-#endif
-
-#ifndef ECHO_SERVER_PORT
-    #error "Please define ECHO_SERVER_PORT"
-#endif
+#if ( TRANSPORT_INTERFACE_TEST_ENABLED == 1 )
+    #ifndef ECHO_SERVER_ENDPOINT
+        #error "Please define ECHO_SERVER_ENDPOINT"
+    #endif
+    
+    #ifndef ECHO_SERVER_PORT
+        #error "Please define ECHO_SERVER_PORT"
+    #endif
+#endif /* if ( TRANSPORT_INTERFACE_TEST_ENABLED == 1 ) */
 
 /*-----------------------------------------------------------*/
 

--- a/src/transport_interface/transport_interface_test.c
+++ b/src/transport_interface/transport_interface_test.c
@@ -99,6 +99,16 @@
 
 /*-----------------------------------------------------------*/
 
+#ifndef ECHO_SERVER_ENDPOINT
+    #error "Please define ECHO_SERVER_ENDPOINT"
+#endif
+
+#ifndef ECHO_SERVER_PORT
+    #error "Please define ECHO_SERVER_PORT"
+#endif
+
+/*-----------------------------------------------------------*/
+
 /**
  * @brief Struct of test parameters filled in by user.
  */

--- a/tools/echo_server/README.md
+++ b/tools/echo_server/README.md
@@ -41,6 +41,7 @@ The JSON file contains the following options:
 
 ## Credential Creation for secure echo server
 ### **Server**
+Note that in order for full TLS verification to work, Common Name (CN) part in the following commands should be replaced with DNS name of the server.
 #### **RSA**
 The following openssl command can be used to generate self-signed server certificate:
 ```bash


### PR DESCRIPTION
This PR has the following changes:
1. Updated README in echo server about setting Common Name to server DNS.
2. Added param check in transport and MQTT test so that if server endpoint and port macros are not defined, the build will error out.