### PR TITLE
Moved the X_TEST_ENABLED guards to cover the entire file

### DIFF
--- a/src/mqtt/mqtt_test.c
+++ b/src/mqtt/mqtt_test.c
@@ -24,6 +24,8 @@
  * @file mqtt_test.c
  * @brief Implements test functions for MQTT test.
  */
+#if ( MQTT_TEST_ENABLED == 1 )
+
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
@@ -1236,23 +1238,23 @@ int RunMqttTest( void )
 {
     int status = -1;
 
-    #if ( MQTT_TEST_ENABLED == 1 )
-        /* Calls user-implemented SetupMqttTestParam to fill in testParam */
-        SetupMqttTestParam( &testParam );
-        testHostInfo.pHostName = MQTT_SERVER_ENDPOINT;
-        testHostInfo.port = MQTT_SERVER_PORT;
+    /* Calls user-implemented SetupMqttTestParam to fill in testParam */
+    SetupMqttTestParam( &testParam );
+    testHostInfo.pHostName = MQTT_SERVER_ENDPOINT;
+    testHostInfo.port = MQTT_SERVER_PORT;
 
-        /* Initialize unity. */
-        UnityFixture.Verbose = 1;
-        UnityFixture.GroupFilter = 0;
-        UnityFixture.NameFilter = 0;
-        UnityFixture.RepeatCount = 1;
+    /* Initialize unity. */
+    UnityFixture.Verbose = 1;
+    UnityFixture.GroupFilter = 0;
+    UnityFixture.NameFilter = 0;
+    UnityFixture.RepeatCount = 1;
 
-        UNITY_BEGIN();
+    UNITY_BEGIN();
 
-        RUN_TEST_GROUP( MqttTest );
+    RUN_TEST_GROUP( MqttTest );
 
-        status = UNITY_END();
-    #endif /* if ( MQTT_TEST_ENABLED == 1 ) */
+    status = UNITY_END();
     return status;
 }
+
+#endif /* if ( MQTT_TEST_ENABLED == 1 ) */

--- a/src/ota/ota_pal_test.c
+++ b/src/ota/ota_pal_test.c
@@ -3,6 +3,8 @@
  * @brief Various tests for validating an implementation to the OTA PAL.
  */
 
+#if ( OTA_PAL_TEST_ENABLED == 1 )
+
 /* Standard includes. */
 #include <stdint.h>
 #include <stdbool.h>
@@ -651,23 +653,23 @@ TEST( Full_OTA_PAL, otaPal_GetPlatformImageState_InvalidImageStateFromFileCloseF
 int RunOtaPalTest( void )
 {
     int status = -1;
-    #if ( OTA_PAL_TEST_ENABLED == 1 )
-        SetupOtaPalTestParam( &testParam );
+    SetupOtaPalTestParam( &testParam );
 
-        /* Initialize unity. */
-        UnityFixture.Verbose = 1;
-        UnityFixture.GroupFilter = 0;
-        UnityFixture.NameFilter = 0;
-        UnityFixture.RepeatCount = 1;
+    /* Initialize unity. */
+    UnityFixture.Verbose = 1;
+    UnityFixture.GroupFilter = 0;
+    UnityFixture.NameFilter = 0;
+    UnityFixture.RepeatCount = 1;
 
-        UNITY_BEGIN();
+    UNITY_BEGIN();
 
-        /* Run the test group. */
-        RUN_TEST_GROUP( Full_OTA_PAL );
+    /* Run the test group. */
+    RUN_TEST_GROUP( Full_OTA_PAL );
 
-        status = UNITY_END();
-    #endif /* if ( OTA_TEST_ENABLED == 1 ) */
+    status = UNITY_END();
     return status;
 }
 
 /*-----------------------------------------------------------*/
+
+#endif /* if ( OTA_TEST_ENABLED == 1 ) */

--- a/src/pkcs11/core_pkcs11_test.c
+++ b/src/pkcs11/core_pkcs11_test.c
@@ -24,6 +24,9 @@
  * @file core_pkcs11_test.c
  * @brief Integration tests for the corePKCS11 implementation.
  */
+
+#if ( CORE_PKCS11_TEST_ENABLED == 1 )
+
 /* Standard includes. */
 #include <stdlib.h>
 #include <string.h>
@@ -2846,33 +2849,33 @@ int RunPkcs11Test( void )
 {
     int status = -1;
 
-    #if ( CORE_PKCS11_TEST_ENABLED == 1 )
-        /* Initialize unity. */
-        UnityFixture.Verbose = 1;
-        UnityFixture.GroupFilter = 0;
-        UnityFixture.NameFilter = 0;
-        UnityFixture.RepeatCount = 1;
-        UNITY_BEGIN();
+    /* Initialize unity. */
+    UnityFixture.Verbose = 1;
+    UnityFixture.GroupFilter = 0;
+    UnityFixture.NameFilter = 0;
+    UnityFixture.RepeatCount = 1;
+    UNITY_BEGIN();
 
-        /* Basic general purpose and slot token management tests. */
-        RUN_TEST_GROUP( Full_PKCS11_StartFinish );
+    /* Basic general purpose and slot token management tests. */
+    RUN_TEST_GROUP( Full_PKCS11_StartFinish );
 
-        /* Cryptoki capabilities test. */
-        RUN_TEST_GROUP( Full_PKCS11_Capabilities );
+    /* Cryptoki capabilities test. */
+    RUN_TEST_GROUP( Full_PKCS11_Capabilities );
 
-        /* Digest and random number generate test. */
-        RUN_TEST_GROUP( Full_PKCS11_NoObject );
+    /* Digest and random number generate test. */
+    RUN_TEST_GROUP( Full_PKCS11_NoObject );
 
-        /* RSA key function test. */
-        RUN_TEST_GROUP( Full_PKCS11_RSA );
+    /* RSA key function test. */
+    RUN_TEST_GROUP( Full_PKCS11_RSA );
 
-        /* EC key function test. */
-        RUN_TEST_GROUP( Full_PKCS11_EC );
+    /* EC key function test. */
+    RUN_TEST_GROUP( Full_PKCS11_EC );
 
-        status = UNITY_END();
-    #endif /* if ( CORE_PKCS11_TEST_ENABLED == 1 ) */
+    status = UNITY_END();
 
     return status;
 }
 
 /*-----------------------------------------------------------*/
+
+#endif /* if ( CORE_PKCS11_TEST_ENABLED == 1 ) */

--- a/src/transport_interface/transport_interface_test.c
+++ b/src/transport_interface/transport_interface_test.c
@@ -25,8 +25,11 @@
  * @brief Integration tests for the transport interface test implementation.
  */
 
+#if ( TRANSPORT_INTERFACE_TEST_ENABLED == 1 )
+
 /* Standard header includes. */
 #include <string.h>
+#include <stdbool.h>
 
 /* Include for init and de-init functions. */
 #include "transport_interface_test.h"
@@ -921,27 +924,27 @@ int RunTransportInterfaceTest( void )
 {
     int status = -1;
 
-    #if ( TRANSPORT_INTERFACE_TEST_ENABLED == 1 )
-        /* Assign the TransportInterface_t pointer used in test cases. */
-        SetupTransportTestParam( &testParam );
-        threadParameter[ 0 ].pNetworkContext = testParam.pNetworkContext;
-        threadParameter[ 1 ].pNetworkContext = testParam.pSecondNetworkContext;
-        testHostInfo.pHostName = ECHO_SERVER_ENDPOINT;
-        testHostInfo.port = ECHO_SERVER_PORT;
+    /* Assign the TransportInterface_t pointer used in test cases. */
+    SetupTransportTestParam( &testParam );
+    threadParameter[ 0 ].pNetworkContext = testParam.pNetworkContext;
+    threadParameter[ 1 ].pNetworkContext = testParam.pSecondNetworkContext;
+    testHostInfo.pHostName = ECHO_SERVER_ENDPOINT;
+    testHostInfo.port = ECHO_SERVER_PORT;
 
-        /* Initialize unity. */
-        UnityFixture.Verbose = 1;
-        UnityFixture.GroupFilter = 0;
-        UnityFixture.NameFilter = 0;
-        UnityFixture.RepeatCount = 1;
-        UNITY_BEGIN();
+    /* Initialize unity. */
+    UnityFixture.Verbose = 1;
+    UnityFixture.GroupFilter = 0;
+    UnityFixture.NameFilter = 0;
+    UnityFixture.RepeatCount = 1;
+    UNITY_BEGIN();
 
-        /* Run the test group. */
-        RUN_TEST_GROUP( Full_TransportInterfaceTest );
+    /* Run the test group. */
+    RUN_TEST_GROUP( Full_TransportInterfaceTest );
 
-        status = UNITY_END();
-    #endif /* if ( TRANSPORT_INTERFACE_TEST_ENABLED == 1 ) */
+    status = UNITY_END();
     return status;
 }
 
 /*-----------------------------------------------------------*/
+
+#endif /* if ( TRANSPORT_INTERFACE_TEST_ENABLED == 1 ) */


### PR DESCRIPTION
Moved the X_TEST_ENABLED guards to cover the entire file. Previously the X_TEST_ENABLED guards only covers the run test functions. When building the project, users might see errors coming from tests that are not enabled. This PR makes all test source excluded from build unless the test is enabled.