### PR TITLE
Moved test_execution_config.h to before test source guard

### DIFF
--- a/src/mqtt/mqtt_test.c
+++ b/src/mqtt/mqtt_test.c
@@ -24,6 +24,8 @@
  * @file mqtt_test.c
  * @brief Implements test functions for MQTT test.
  */
+
+#include "test_execution_config.h"
 #if ( MQTT_TEST_ENABLED == 1 )
 
 #include <assert.h>
@@ -39,7 +41,6 @@
 #include "unity_fixture.h"
 
 #include "mqtt_test.h"
-#include "test_execution_config.h"
 #include "test_param_config.h"
 #include "platform_function.h"
 

--- a/src/ota/ota_pal_test.c
+++ b/src/ota/ota_pal_test.c
@@ -3,6 +3,7 @@
  * @brief Various tests for validating an implementation to the OTA PAL.
  */
 
+#include "test_execution_config.h"
 #if ( OTA_PAL_TEST_ENABLED == 1 )
 
 /* Standard includes. */
@@ -21,7 +22,6 @@
 #include "ota_pal.h"
 
 #include "ota_pal_test.h"
-#include "test_execution_config.h"
 #include "test_param_config.h"
 
 #ifndef OTA_PAL_TEST_CERT_TYPE

--- a/src/pkcs11/core_pkcs11_test.c
+++ b/src/pkcs11/core_pkcs11_test.c
@@ -25,6 +25,7 @@
  * @brief Integration tests for the corePKCS11 implementation.
  */
 
+#include "test_execution_config.h"
 #if ( CORE_PKCS11_TEST_ENABLED == 1 )
 
 /* Standard includes. */
@@ -58,7 +59,6 @@
 #include "ecdsa_test_credentials.h"
 
 /* Test configuration includes. */
-#include "test_execution_config.h"
 #include "test_param_config.h"
 
 /*-----------------------------------------------------------*/

--- a/src/transport_interface/transport_interface_test.c
+++ b/src/transport_interface/transport_interface_test.c
@@ -25,6 +25,7 @@
  * @brief Integration tests for the transport interface test implementation.
  */
 
+#include "test_execution_config.h"
 #if ( TRANSPORT_INTERFACE_TEST_ENABLED == 1 )
 
 /* Standard header includes. */
@@ -35,7 +36,6 @@
 #include "transport_interface_test.h"
 
 /* Include for test parameter and execution configs. */
-#include "test_execution_config.h"
 #include "test_param_config.h"
 
 /* Include for Unity framework. */


### PR DESCRIPTION
Moved test_execution_config.h to before test source guard. Otherwise the test source will still be excluded by preprocessor when test is enabled in test_execution_config.h.